### PR TITLE
Various fixes and QoL additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Bicleaner Hardrules 2.10.1:
+Bicleaner Hardrules 2.11:
 * Fix division by 0 error on empty sentences.
 * Fix rules that were giving false positives on empty sentences (no_titles, wrong_language)
 * For performance, long sentences (> 10000 characters) are ignored by default, only "not_too_long" is outputed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Bicleaner Hardrules 2.11:
+Bicleaner Hardrules 2.10.1:
 * Fix division by 0 error on empty sentences.
 * Fix rules that were giving false positives on empty sentences (no_titles, wrong_language)
 * For performance, long sentences (> 10000 characters) are ignored by default, only "not_too_long" is outputed.
@@ -7,7 +7,6 @@ Bicleaner Hardrules 2.11:
 Bicleaner Hardrules 2.10.0:
 * Update FastSpell to 0.10 with more languages support:
   * https://github.com/mbanon/fastspell/blob/v0.10/CHANGELOG.md
-
 
 Bicleaner Hardrules 2.9.1:
 * Fix hardrules crash without metadata.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Bicleaner Hardrules 2.10.1:
+* Fix division by 0 error on empty sentences.
+* Fix rules that were giving false positives on empty sentences (no_titles, wrong_language)
+* For performance, long sentences (> 10000 characters) are ignored by default, only "not_too_long" is outputed.
+  * Added "--dont_ignore_long" to override this behaviour
+
 Bicleaner Hardrules 2.10.0:
 * Update FastSpell to 0.10 with more languages support:
   * https://github.com/mbanon/fastspell/blob/v0.10/CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ bicleaner-hardrules [-h]
                     [--tcol TCOL]
                     [--disable_lm_filter]
                     [--disable_porn_removal]
+                    [--dont_ignore_long]
                     [--metadata METADATA]
                     [--lm_threshold LM_THRESHOLD]
                     [-q]
@@ -111,7 +112,8 @@ bicleaner-hardrules [-h]
   * `--disable_hardrules`: Disables the bicleaner_hardrules filtering (only bicleaner_classify is applied) (default: False)
   * `--disable_lm_filter`: Disables LM filtering.
   * `--disable_porn_removal`: Disables porn removal.
-  * `--disable_minimal_length` : Don't apply minimal length rule (default: False).
+  * `--disable_minimal_length`: Don't apply minimal length rule (default: False).
+  * `--dont_ignore_long`: Don't ingore sentences that are longer than 10000 characters (default: False).
   * `-h, --help`: show this help message and exit
 
 * Logging:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bicleaner-hardrules"
-version = "2.11"
+version = "2.10.1"
 authors = [
     { name="Prompsit Language Engineering", email="info@prompsit.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bicleaner-hardrules"
-version = "2.9.1"
+version = "2.10.1"
 authors = [
     { name="Prompsit Language Engineering", email="info@prompsit.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bicleaner-hardrules"
-version = "2.10.1"
+version = "2.11"
 authors = [
     { name="Prompsit Language Engineering", email="info@prompsit.com" },
 ]

--- a/src/hardrules/bicleaner_hardrules.py
+++ b/src/hardrules/bicleaner_hardrules.py
@@ -259,7 +259,7 @@ def worker_process(i, jobs_queue, output_queue, args):
                         fileout.write("\t".join(parts) + "\t")
 
                     # Check if dont_ignore_long is enabled and TU is longer than allowed
-                    if not args.dont_ignore_long and (len(left) > 10000 and len(right) > 10000):
+                    if not args.dont_ignore_long and (len(left) > 10000 or len(right) > 10000):
                         wrong_tu_results = ["c_not_too_long"]
 
                     # Run hardrules for TU if all previous checks pass


### PR DESCRIPTION
Fixed:
 - Azerbaijani getting discarded by unicode rule
 - Relaxing threshold of length_ratio rule from 2.0 to 3.0, should be better for CJK languages
 - Fixes to some rules when division by 0 occurred
 - Fix to empty sentences being tagged with anything other than no_empty
 - Added dont_ignore_long parameter along with the functionality to ignore sentences over 10k chars long
 - Added Urdu, Swahili, Burmese, Somali, Bengali, Farsi and Gujarati to the list of safe noise detection languages for no_repeated_words rule